### PR TITLE
Fix: Update RenderPrefix signature for DV B99 compatibility

### DIFF
--- a/CL.Game/Patches/BookletCreator_StaticRenderBookletPatches.cs
+++ b/CL.Game/Patches/BookletCreator_StaticRenderBookletPatches.cs
@@ -11,7 +11,7 @@ namespace CL.Game.Patches
     {
 
         [HarmonyPrefix, HarmonyPatch(nameof(BookletCreator_StaticRenderBooklet.Render))]
-        public static bool RenderPrefix(GameObject existingBooklet, string renderPrefabName, ref RenderedTexturesBooklet __result)
+        public static bool RenderPrefix(GameObject existingBooklet, string renderPrefabName, ref RenderedTexturesBase __result)
         {
             if (!LicenseManager.KeyToPrefab.TryGetValue(renderPrefabName, out var result))
             {


### PR DESCRIPTION
After the B99 update, the Harmony patch for `BookletCreator_StaticRenderBooklet.Render` was failing due to a method signature mismatch, [preventing Custom Licenses from starting](https://github.com/WhistleWiz/dv-custom-licenses/issues/1#issue-2690680318). The return type of the method was changed in the game's code. It now returns `RenderedTexturesBase` instead of `RenderedTexturesBooklet`.

I have partially tested this change in-game on Derail Valley Build 99 and confirmed that (for now) nothing else broke. **The mod loads and the custom licenses are appearing.**

However, I'm unsure if other things also broke, So I'll leave this as a draft until I complete a few tests.

Tests:
 - ✅ Mod loads without errors
 - ✅ Custom licenses appear correctly in-game
 - ✅ Purchased licenses persist across saves
 - ❌ Custom licenses are ignoring license dependency-> *I might have done something wrong in [my `license.json` files](https://github.com/WhistleWiz/dv-custom-licenses/pull/2#issuecomment-3086474086)*
 - ❌ Licenses are not kept in inventory across saves -> *Is it by design?*
 - ❔Are custom licenses affecting gameplay? -> *TODO*